### PR TITLE
Enhance OpenAI assistant with context memory and caching

### DIFF
--- a/ai-assistant.js
+++ b/ai-assistant.js
@@ -1,6 +1,5 @@
 class AIPortfolioAssistant {
     constructor() {
-        this.analysisCache = new Map();
         this.recommendations = [];
     }
 


### PR DESCRIPTION
## Summary
- Store user context and merge it into questions automatically
- Cache responses to repeated questions for faster reuse
- Limit chat history and cache sizes to avoid unbounded growth
- Clear caches when chat history resets

## Testing
- `node --check openai-assistant.js`
- `node --check ai-assistant.js`


------
https://chatgpt.com/codex/tasks/task_b_68c2151ec998832281ba19b0828a60c5