### PR TITLE
Remove duplicate tab navigation setup

### DIFF
--- a/portfolio-manager.js
+++ b/portfolio-manager.js
@@ -7,7 +7,6 @@ class PortfolioManager {
     }
 
     init() {
-        setupTabNavigation();
         this.loadSavedData();
         this.updateCompositionDisplay();
         this.setupCompositionEditor();


### PR DESCRIPTION
## Summary
- Avoid duplicate tab navigation event bindings by removing redundant setup call in portfolio manager initialization.

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c21797e330832281a67071975bc95c