### PR TITLE
Remove duplicate tab navigation setup

### DIFF
--- a/portfolio-manager.js
+++ b/portfolio-manager.js
@@ -7,7 +7,6 @@ class PortfolioManager {
     }
 
     init() {
-        setupTabNavigation();
         this.loadSavedData();
         this.updateCompositionDisplay();
         this.setupCompositionEditor();

--- a/tab-navigation.js
+++ b/tab-navigation.js
@@ -2,6 +2,12 @@ function setupTabNavigation(loadCallback) {
     const tabBtns = document.querySelectorAll('.tab-btn');
     const tabContents = document.querySelectorAll('.tab-content');
 
+    // Prevent duplicate initialization
+    if (document.body.dataset.tabsInitialized === 'true') {
+        return;
+    }
+    document.body.dataset.tabsInitialized = 'true';
+
     tabBtns.forEach(btn => {
         btn.addEventListener('click', () => {
             const targetTab = btn.dataset.tab;
@@ -22,4 +28,10 @@ function setupTabNavigation(loadCallback) {
             }
         });
     });
+
+    // Trigger load for initially active tab
+    const activeBtn = document.querySelector('.tab-btn.active');
+    if (activeBtn && typeof loadCallback === 'function') {
+        loadCallback(activeBtn.dataset.tab);
+    }
 }


### PR DESCRIPTION
## Summary
- Avoid duplicate tab navigation event bindings by removing redundant setup call in portfolio manager initialization.
- Guard against reinitializing tab events and trigger the active tab's loader on startup.

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c21797e330832281a67071975bc95c